### PR TITLE
Remove hardwired dependence on react-native 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "mocha ./test/* --compilers js:mocha-traceur"
   },
   "dependencies": {
-    "react-native": "0.4.4"
+    "react-native": "<=0.11.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Package works with react-native 0.11.4, but broke for me on 0.12.0.

Since 0.12.0 was just released yesterday, I haven't created an issue yet because I want to wait till the code base settles a bit.
