### PR TITLE
Add support for passing in an options dictionary to the authorize call.

### DIFF
--- a/iOS/SimpleAuthWrapper.m
+++ b/iOS/SimpleAuthWrapper.m
@@ -13,8 +13,9 @@ RCT_EXPORT_METHOD(configure:(NSString*)provider config:(NSDictionary*)config
 };
 
 RCT_EXPORT_METHOD(authorize:(NSString*)provider
+                  options:(NSDictionary*)opts
                   callback:(RCTResponseSenderBlock)callback) {
-  [SimpleAuth authorize:provider completion:^(id responseObject, NSError *error) {
+  [SimpleAuth authorize:provider options:opts completion:^(id responseObject, NSError *error) {
 
     NSLog(@"\nResponse: %@\nError:%@", responseObject, error);
     

--- a/lib/simpleauthclient.js
+++ b/lib/simpleauthclient.js
@@ -97,9 +97,13 @@ class SimpleAuthClient {
    * @param {string} provider The provider id.
    * @returns {Promise}
    */
-  authorize(provider) {
+  authorize(provider, opts) {
+    if (!opts) {
+      opts = {};
+    }
+
     return new Promise((resolve, reject) => {
-      SimpleAuthWrapper.authorize(provider, function(error, credentials, info) {
+      SimpleAuthWrapper.authorize(provider, opts, function(error, credentials, info) {
         if (error) {
           reject(error);
         } else {


### PR DESCRIPTION
See: https://github.com/calebd/SimpleAuth/blob/master/Pod/Core/SimpleAuth.m#L37

SimpleAuth simply calls the `authorize` method with nil options.

This PR allows passing in an options array, such as:

```
SimpleAuthClient.authorize('instagram', {scope: ['likes', 'comments']});
```

This should be backwards compatible with previous versions.
