### PR TITLE
iOS fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # react-native-simple-auth [![Build Status](https://travis-ci.org/adamjmcgrath/react-native-simple-auth.svg?branch=chore%2Frelease-tasks)](https://travis-ci.org/adamjmcgrath/react-native-simple-auth)
 
+Fork of original react-native-simple-auth with fixes to run in Safari View under iOS to avoid AppStore publishing issues
+
 ## OAuth login for React Native
 
   * [Screencast](#screencast)

--- a/lib/platforms/react-native.js
+++ b/lib/platforms/react-native.js
@@ -1,6 +1,20 @@
 import { Linking } from 'react-native'; // eslint-disable-line import/no-unresolved, max-len
+import SafariView from "react-native-safari-view";
 
-export const dance = authUrl => Linking.openURL(authUrl)
+function openURL(authUrl)
+{
+  if (Platform.OS === 'iOS')
+  {
+    return SafariView.show({
+      url: authUrl,
+      fromBottom: true
+    });
+  } 
+  else
+    return Linking.openURL(authUrl);
+}
+
+export const dance = authUrl => openURL(authUrl)
   .then(() => new Promise((resolve, reject) => {
     const handleUrl = (url) => {
       if (!url || url.indexOf('fail') > -1) {

--- a/lib/platforms/react-native.js
+++ b/lib/platforms/react-native.js
@@ -1,4 +1,4 @@
-import { Linking } from 'react-native'; // eslint-disable-line import/no-unresolved, max-len
+import { Linking, Platform } from 'react-native'; // eslint-disable-line import/no-unresolved, max-len
 import SafariView from "react-native-safari-view";
 
 function openURL(authUrl)

--- a/lib/platforms/react-native.js
+++ b/lib/platforms/react-native.js
@@ -3,7 +3,7 @@ import SafariView from "react-native-safari-view";
 
 function openURL(authUrl)
 {
-  if (Platform.OS === 'iOS')
+  if (Platform.OS === 'ios')
   {
     return SafariView.show({
       url: authUrl,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "react-native-simple-auth",
+  "version": "2.1.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "react-native-safari-view": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-safari-view/-/react-native-safari-view-2.1.0.tgz",
+      "integrity": "sha1-HgzRLGK855vBdZx+KBZGsIthyVk="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "hmacsha1": "^1.0.0",
-    "ramda": "^0.22.1"
+    "ramda": "^0.22.1",
+    "react-native-safari-view": "^2.1.0"
   }
 }


### PR DESCRIPTION
According to AppStore requirements we can't open browser as a separate app in iOS, our last app has been declined because of this. So I've added a possibility to be able to use SafariView under iOS for this. So the integration is seemless and works out of the box. Now the library is fully compatible with both platforms.