### PR TITLE
auth_type parameter for Facebook

### DIFF
--- a/lib/providers/facebook.js
+++ b/lib/providers/facebook.js
@@ -30,14 +30,14 @@ const FIELDS = [
 
 export const authorize = (
   { dance, request },
-  { appId, callback, scope = SCOPE, fields = FIELDS },
+  { appId, callback, scope = SCOPE, fields = FIELDS, authType = 'https' },
 ) => pipeP(
   dance,
   replace('#', '?'),
   fromQueryString,
   set(lensProp('credentials'), __, {}),
   merge({ fields }),
-)(authorizationUrl(AUTH, appId, callback, scope));
+)(authorizationUrl(AUTH, appId, callback, scope, authType));
 
 export const identify = curry((request, { credentials, fields }) => pipeP(
   partial(

--- a/lib/providers/google.js
+++ b/lib/providers/google.js
@@ -53,7 +53,7 @@ export const authorize = (
     fromQueryString,
     checkError,
     merge({ appId, callback }),
-  )(authorizationUrl(AUTH, appId, callback, scope, 'code'));
+  )(authorizationUrl(AUTH, appId, callback, scope, null, 'code'));
 
 export const identify = curry((request, { appId, callback, code }) =>
   pipeP(

--- a/lib/utils/oauth2.js
+++ b/lib/utils/oauth2.js
@@ -3,10 +3,11 @@ import {
 } from 'ramda';
 
 export const authorizationUrl = curry(
-  (url, appId, callback, scope, responseType = 'token') =>
+  (url, appId, callback, scope, authType = 'https', responseType = 'token') =>
     `${url}?scope=${encodeURIComponent(scope)}&
       redirect_uri=${encodeURIComponent(callback)}&
       response_type=${responseType}&
+      auth_type=${authType}&
       client_id=${appId}`.replace(/\s+/g, ''),
   );
 


### PR DESCRIPTION
From original documents: "If someone has declined a permission for your app, the login dialog won't let your app re-request the permission unless you pass auth_type=rerequest along with your request."

The default value to ask for permissions for the first time is "https", and to request again for declined permissions is "rerequest".

This PR adds support for auth_type parameter.

https://developers.facebook.com/docs/facebook-login/permissions/requesting-and-revoking