### PR TITLE
Abandon auth dance if app becomes active without a callback URL

### DIFF
--- a/lib/platforms/react-native.js
+++ b/lib/platforms/react-native.js
@@ -1,11 +1,25 @@
-import { Linking } from 'react-native'; // eslint-disable-line import/no-unresolved, max-len
+import { Linking, AppState } from 'react-native'; // eslint-disable-line import/no-unresolved, max-len
 
-let previousOnLinkChange;
+let appStateTimeout;
+let previousLinkingCallback;
+let previousAppStateCallback;
+
+const cleanup = () => {
+  clearTimeout(appStateTimeout);
+
+  if (previousLinkingCallback) {
+    Linking.removeEventListener('url', previousLinkingCallback);
+    previousLinkingCallback = null;
+  }
+
+  if (previousAppStateCallback) {
+    AppState.removeEventListener('change', previousAppStateCallback);
+    previousAppStateCallback = null;
+  }
+};
 
 export const dance = (authUrl) => {
-  if (previousOnLinkChange) {
-    Linking.removeEventListener('url', previousOnLinkChange);
-  }
+  cleanup();
 
   return Linking.openURL(authUrl)
     .then(() => new Promise((resolve, reject) => {
@@ -17,15 +31,26 @@ export const dance = (authUrl) => {
         }
       };
 
-      const onLinkChange = ({ url }) => {
-        Linking.removeEventListener('url', onLinkChange);
-        previousOnLinkChange = undefined;
+      const linkingCallback = ({ url }) => {
+        cleanup();
         handleUrl(url);
       };
 
-      Linking.addEventListener('url', onLinkChange);
+      Linking.addEventListener('url', linkingCallback);
+      previousLinkingCallback = linkingCallback;
 
-      previousOnLinkChange = onLinkChange;
+      const appStateCallback = (state) => {
+        // Give time for Linking event to fire.
+        appStateTimeout = setTimeout(() => {
+          if (state === 'active') {
+            cleanup();
+            reject('cancelled');
+          }
+        }, 100);
+      };
+
+      AppState.addEventListener('change', appStateCallback);
+      previousAppStateCallback = appStateCallback;
     }));
 };
 


### PR DESCRIPTION
For auth flows that kick out to Mobile Safari, the user may abandon the flow by returning to the React Native app. In this scenario, the authorization never completes, even though it's functionally been cancelled.

This PR adds RN platform-specific logic to monitor `AppState` and cancel the auth request if the app reactivates without the `Linking` module receiving a callback URL.